### PR TITLE
Add spec values to ingress

### DIFF
--- a/cockroachdb/templates/ingress.yaml
+++ b/cockroachdb/templates/ingress.yaml
@@ -32,6 +32,11 @@ metadata:
 {{- toYaml .Values.ingress.labels | nindent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.spec }}
+{{- range $key, $value := .Values.ingress.spec }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
   rules:
   {{- if .Values.ingress.hosts }}
   {{- range $host := .Values.ingress.hosts }}


### PR DESCRIPTION
This enables us to inject spec key values to the db console ingress resource.